### PR TITLE
Ignore import/no-commonjs errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,7 +44,8 @@
       "semi": "off",
       "@typescript-eslint/semi": ["error", "never"],
       "@typescript-eslint/type-annotation-spacing": "error",
-      "@typescript-eslint/unbound-method": "error"
+      "@typescript-eslint/unbound-method": "error",
+      "import/no-commonjs": "warn"
     },
     "env": {
       "node": true,


### PR DESCRIPTION
Seems it's added by more recent versions of eslint-plugin-github