### PR TITLE
Support ignoring job and matrix jobs as part of cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ See `extraFiles` for more details.
 
 The content of `extraHashedContent` is taken into account in the hash for the coursier cache key.
 
+### `ignoreJob`
+
+*Optional*
+
+Default: `false`
+
+Set `true` if you don't want to use a job id as part of cache key.
+
+### `ignoreMatrix`
+
+*Optional*
+
+Default: `false`
+
+Set `true` if you don't want to use a matrix jobs as part of cache key.
+
 ## Outputs
 
 * `cache-hit-coursier` - A boolean value to indicate a match was found for the coursier cache

--- a/action.yml
+++ b/action.yml
@@ -109,6 +109,16 @@ inputs:
     description: >
       Extra content to take into account in the Ammonite cache key. Same format as extraHashedContent.
     default: ''
+  ignoreJob:
+    required: false
+    description: >
+      Set 'true' if you don't want to use a job id as part of cache key.
+    default: 'false'
+  ignoreMatrix:
+    required: false
+    description: >
+      Set 'true' if you don't want to use a matrix jobs as part of cache key.
+    default: 'false'
 outputs:
   cache-hit-coursier:
     description: 'A boolean value to indicate a match was found for the coursier cache'

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -300,6 +300,10 @@ function readExtraKeys(variableName: string): string {
   return extraFilesStr
 }
 
+function readExtraBoolean(variableName: string): boolean {
+  return core.getBooleanInput(variableName, {required: false})
+}
+
 async function run(): Promise<void> {
   let root = core.getInput('root')
   if (!root.endsWith('/')) {
@@ -345,9 +349,17 @@ async function run(): Promise<void> {
   const extraMillKey = readExtraKeys('extraMillKey')
   const extraAmmoniteKey = readExtraKeys('extraAmmoniteKey')
 
-  const job = readExtraKeys('job')
+  const ignoreJobAsPartCacheKey = readExtraBoolean('ignoreJob')
+  const ignoreMatrixAsPartCacheKey = readExtraBoolean('ignoreMatrix')
+
+  const job = ignoreJobAsPartCacheKey ? '' : readExtraKeys('job')
   let matrix = readExtraKeys('matrix')
-  if (matrix === 'null' || matrix === 'undefined' || matrix === '{}') {
+  if (
+    matrix === 'null' ||
+    matrix === 'undefined' ||
+    matrix === '{}' ||
+    ignoreMatrixAsPartCacheKey
+  ) {
     matrix = ''
   }
 


### PR DESCRIPTION
Hi, @alexarchambault! 
This feature will be very useful for us in Playframework. We have about 15 pair (coursier + ivy) very similar cache entries per build (summary more then 20Gb). But in fact we need only one pair of them about 1.4Gb.
It can give us ability don't exceed a GitHub Actions Cache size limit (10Gb).

PS: Changes is very simple, but I don't know how to test it. Sorry, TS isn't my skill 🤷‍♂️ 