### PR TITLE
Add option to disable cross-job fallback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           root: test
           extraFiles: test/foo.sh # for the ammonite version?
+          disableCrossJobFallback: true
 
       - run: cd test && eval "$(./cs java --env --jvm 17)" && ./mill -i __.compile && ./foo.sh
         if: runner.os != 'Windows'

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ Default: `false`
 
 Set `true` to disable falling back to a less specific cache key when there is no exact cache hit. By default, if no exact cache match is found, the action will restore from a more general cache key (e.g. from a different job or build configuration). Disabling this prevents unintended cache sharing across jobs or matrix instances that have different dependency sets.
 
+### `disableCrossJobFallback`
+
+*Optional*
+
+Default: `false`
+
+Set `true` to omit fallback keys shared by different jobs while retaining less-specific fallback
+keys within the current job. For example, a `tests` job can restore `coursier-tests-...` caches but
+cannot restore a `coursier-scalafmt-...` cache. This option has no effect when `ignoreJob` is `true`.
+
 ## Cache invalidation
 
 To manually invalidate the cache without changing your build files, set the `COURSIER_CACHE_ACTION_CACHE_VERSION`

--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,14 @@ inputs:
       prevents unintended cache sharing across jobs or matrix instances that have different
       dependency sets.
     default: 'false'
+  disableCrossJobFallback:
+    required: false
+    description: >
+      Set 'true' to omit fallback keys shared by different jobs while retaining less-specific
+      fallback keys within the current job. This prevents one job from restoring another job's
+      cache without making every build configuration change a full cache miss. This option has
+      no effect when ignoreJob is 'true'.
+    default: 'false'
 outputs:
   cache-hit-coursier:
     description: 'A boolean value to indicate a match was found for the coursier cache'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
-    "test": "echo 'No test framework configured'",
+    "test": "node --experimental-strip-types --test test/*.test.ts",
     "all": "npm run build && npm run format-check && npm run lint && npm test"
   },
   "repository": {

--- a/src/cache-keys.ts
+++ b/src/cache-keys.ts
@@ -1,0 +1,47 @@
+export interface CacheKeyParts {
+  id: string
+  job: string
+  matrixHash: string
+  extraSharedKey: string
+  extraKey: string
+  inputHash: string
+  disableCrossJobFallback: boolean
+}
+
+export interface CacheKeys {
+  key: string
+  restoreKeys: string[]
+}
+
+export function buildCacheKeys(parts: CacheKeyParts): CacheKeys {
+  let key = parts.id
+  const restoreKeys: string[] = []
+
+  if (parts.job.length > 0) {
+    if (!parts.disableCrossJobFallback) restoreKeys.push(`${key}-`)
+    key = `${key}-${parts.job}`
+  }
+
+  if (parts.matrixHash.length > 0) {
+    restoreKeys.push(`${key}-`)
+    key = `${key}-matrix-${parts.matrixHash}`
+  }
+
+  if (parts.extraSharedKey.length > 0) {
+    restoreKeys.push(`${key}-`)
+    key = `${key}-${parts.extraSharedKey}`
+  }
+
+  if (parts.extraKey.length > 0) {
+    restoreKeys.push(`${key}-`)
+    key = `${key}-${parts.extraKey}`
+  }
+
+  if (parts.inputHash.length > 0) {
+    restoreKeys.push(`${key}-`)
+    key = `${key}-${parts.inputHash}`
+  }
+
+  restoreKeys.reverse()
+  return {key, restoreKeys}
+}

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -2,6 +2,7 @@ import * as cache from '@actions/cache'
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as glob from '@actions/glob'
+import {buildCacheKeys} from './cache-keys.js'
 import {stat} from 'fs'
 import {readFile, unlink, writeFile} from 'fs/promises'
 let _unameValue = ''
@@ -90,44 +91,36 @@ async function restoreCache(
   extraKey: string,
   matrixHashedContent: string,
   extraHashedContent: string,
-  disableFallback: boolean
+  disableFallback: boolean,
+  disableCrossJobFallback: boolean
 ): Promise<void> {
   const upperId = id.toLocaleUpperCase('en-US')
   const cacheHitId = `cache-hit-${id}`
 
-  let key = id
-  const restoreKeys: string[] = []
+  const matrixHash =
+    matrixHashedContent.length > 0
+      ? await hashContent([], matrixHashedContent)
+      : ''
+  const inputHash =
+    inputFiles.length > 0 || extraHashedContent.length > 0
+      ? await hashContent(inputFiles, extraHashedContent)
+      : ''
+  const {key, restoreKeys} = buildCacheKeys({
+    id,
+    job,
+    matrixHash,
+    extraSharedKey,
+    extraKey,
+    inputHash,
+    disableCrossJobFallback
+  })
 
-  if (job.length > 0) {
-    restoreKeys.push(`${key}-`)
-    key = `${key}-${job}`
-  }
-
-  if (matrixHashedContent.length > 0) {
-    restoreKeys.push(`${key}-`)
-    const matrixHash = await hashContent([], matrixHashedContent)
-    key = `${key}-matrix-${matrixHash}`
-  }
-
-  if (extraSharedKey.length > 0) {
-    restoreKeys.push(`${key}-`)
-    key = `${key}-${extraSharedKey}`
-  }
-
-  if (extraKey.length > 0) {
-    restoreKeys.push(`${key}-`)
-    key = `${key}-${extraKey}`
-  }
-
-  if (inputFiles.length > 0 || extraHashedContent.length > 0) {
-    restoreKeys.push(`${key}-`)
-    const hash = await hashContent(inputFiles, extraHashedContent)
-    key = `${key}-${hash}`
-  }
-
-  restoreKeys.reverse()
-
-  core.info(`${id} cache keys${disableFallback ? ' (fallback disabled)' : ''}:`)
+  const fallbackStatus = disableFallback
+    ? ' (fallback disabled)'
+    : disableCrossJobFallback
+      ? ' (cross-job fallback disabled)'
+      : ''
+  core.info(`${id} cache keys${fallbackStatus}:`)
   core.info(`  ${key}`)
   for (const restoreKey of restoreKeys) {
     core.info(`  ${restoreKey}`)
@@ -176,7 +169,8 @@ async function restoreCoursierCache(
   extraKey: string,
   matrixHashedContent: string,
   extraHashedContent: string,
-  disableFallback: boolean
+  disableFallback: boolean,
+  disableCrossJobFallback: boolean
 ): Promise<void> {
   let paths: string[] = []
 
@@ -197,7 +191,8 @@ async function restoreCoursierCache(
     extraKey,
     matrixHashedContent,
     extraHashedContent,
-    disableFallback
+    disableFallback,
+    disableCrossJobFallback
   )
 }
 
@@ -208,7 +203,8 @@ async function restoreSbtCache(
   extraKey: string,
   matrixHashedContent: string,
   extraHashedContent: string,
-  disableFallback: boolean
+  disableFallback: boolean,
+  disableCrossJobFallback: boolean
 ): Promise<void> {
   await restoreCache(
     'sbt-ivy2-cache',
@@ -219,7 +215,8 @@ async function restoreSbtCache(
     extraKey,
     matrixHashedContent,
     extraHashedContent,
-    disableFallback
+    disableFallback,
+    disableCrossJobFallback
   )
 }
 
@@ -230,7 +227,8 @@ async function restoreMillCache(
   extraKey: string,
   matrixHashedContent: string,
   extraHashedContent: string,
-  disableFallback: boolean
+  disableFallback: boolean,
+  disableCrossJobFallback: boolean
 ): Promise<void> {
   await restoreCache(
     'mill',
@@ -241,7 +239,8 @@ async function restoreMillCache(
     extraKey,
     matrixHashedContent,
     extraHashedContent,
-    disableFallback
+    disableFallback,
+    disableCrossJobFallback
   )
 }
 
@@ -252,7 +251,8 @@ async function restoreAmmoniteCache(
   extraKey: string,
   matrixHashedContent: string,
   extraHashedContent: string,
-  disableFallback: boolean
+  disableFallback: boolean,
+  disableCrossJobFallback: boolean
 ): Promise<void> {
   await restoreCache(
     'ammonite',
@@ -263,7 +263,8 @@ async function restoreAmmoniteCache(
     extraKey,
     matrixHashedContent,
     extraHashedContent,
-    disableFallback
+    disableFallback,
+    disableCrossJobFallback
   )
 }
 
@@ -345,6 +346,7 @@ async function run(): Promise<void> {
   const ignoreMatrixAsPartCacheKey = readExtraBoolean('ignoreMatrix')
   const ignoreAmmonite = readExtraBoolean('ignoreAmmonite')
   const disableFallback = readExtraBoolean('disableFallback')
+  const disableCrossJobFallback = readExtraBoolean('disableCrossJobFallback')
 
   const job = ignoreJobAsPartCacheKey ? '' : readExtraKeys('job')
   let matrix = readExtraKeys('matrix')
@@ -405,7 +407,8 @@ async function run(): Promise<void> {
     extraCoursierKey,
     matrix,
     JSON.stringify(coursierHashedContent),
-    disableFallback
+    disableFallback,
+    disableCrossJobFallback
   )
 
   if (hasSbtFiles) {
@@ -419,7 +422,8 @@ async function run(): Promise<void> {
         sbt: extraSbtHashedContent,
         other: effectiveExtraHashedContent
       }),
-      disableFallback
+      disableFallback,
+      disableCrossJobFallback
     )
   }
 
@@ -434,7 +438,8 @@ async function run(): Promise<void> {
         mill: extraMillHashedContent,
         other: effectiveExtraHashedContent
       }),
-      disableFallback
+      disableFallback,
+      disableCrossJobFallback
     )
   }
 
@@ -457,7 +462,8 @@ async function run(): Promise<void> {
         amm: extraAmmoniteHashedContent,
         other: effectiveExtraHashedContent
       }),
-      disableFallback
+      disableFallback,
+      disableCrossJobFallback
     )
   }
 }

--- a/test/cache-keys.test.ts
+++ b/test/cache-keys.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {buildCacheKeys} from '../src/cache-keys.ts'
+
+const baseParts = {
+  id: 'coursier',
+  job: 'tests',
+  matrixHash: '',
+  extraSharedKey: '',
+  extraKey: '',
+  inputHash: 'build-hash'
+}
+
+test('default fallbacks include same-job and cross-job prefixes', () => {
+  assert.deepEqual(
+    buildCacheKeys({...baseParts, disableCrossJobFallback: false}),
+    {
+      key: 'coursier-tests-build-hash',
+      restoreKeys: ['coursier-tests-', 'coursier-']
+    }
+  )
+})
+
+test('cross-job fallback can be disabled without disabling same-job fallback', () => {
+  assert.deepEqual(
+    buildCacheKeys({...baseParts, disableCrossJobFallback: true}),
+    {
+      key: 'coursier-tests-build-hash',
+      restoreKeys: ['coursier-tests-']
+    }
+  )
+})
+
+test('cross-job fallback option is inert when job keys are ignored', () => {
+  assert.deepEqual(
+    buildCacheKeys({
+      ...baseParts,
+      job: '',
+      disableCrossJobFallback: true
+    }),
+    {
+      key: 'coursier-build-hash',
+      restoreKeys: ['coursier-']
+    }
+  )
+})


### PR DESCRIPTION
## Problem

Fallback keys become progressively broader. When a job-specific key misses, the final cache-type prefix can restore another job's cache. GitHub's branch-scoped lookup can therefore select a current-branch formatting cache before a base-branch tests cache.

`disableFallback` prevents contamination but also discards useful same-job fallbacks after a build-definition change.

## Change

Add `disableCrossJobFallback`. It omits the cache-type-wide fallback while retaining less-specific keys within the current job.

For a changed `tests` build:

```text
exact:     coursier-tests-<new hash>
fallback:  coursier-tests-
omitted:   coursier-
```

The default remains unchanged.

## Verification

- Added unit coverage for default, isolated-job, and ignored-job behavior.
- Ran build, formatting, lint, tests, and TypeScript type checking.